### PR TITLE
feat: [PL-5903] Add missing DTD enum values

### DIFF
--- a/Customer.Api/Symend.Client.Customer/src/Symend.Client.Customer/Model/DataTargetDefinitionCategory.cs
+++ b/Customer.Api/Symend.Client.Customer/src/Symend.Client.Customer/Model/DataTargetDefinitionCategory.cs
@@ -78,7 +78,7 @@ namespace Symend.Client.Customer.Model
         /// Enum Property for value: property
         /// </summary>
         [EnumMember(Value = "property")]
-        Property = 8
+        Property = 8,
 
         /// <summary>
         /// Enum InsightEnablement for value: insightEnablement

--- a/Customer.Api/Symend.Client.Customer/src/Symend.Client.Customer/Model/DataTargetDefinitionCategory.cs
+++ b/Customer.Api/Symend.Client.Customer/src/Symend.Client.Customer/Model/DataTargetDefinitionCategory.cs
@@ -80,6 +80,17 @@ namespace Symend.Client.Customer.Model
         [EnumMember(Value = "property")]
         Property = 8
 
+        /// <summary>
+        /// Enum InsightEnablement for value: insightEnablement
+        /// </summary>
+        [EnumMember(Value = "insightEnablement")]
+        InsightEnablement = 9,
+
+        /// <summary>
+        /// Enum CureScoresArchetypes for value: cureScoresArchetypes
+        /// </summary>
+        [EnumMember(Value = "cureScoresArchetypes")]
+        CureScoresArchetypes = 10
     }
 
 }

--- a/Customer.Api/Symend.Client.Customer/src/Symend.Client.Customer/Model/DataTargetDefinitionDataType.cs
+++ b/Customer.Api/Symend.Client.Customer/src/Symend.Client.Customer/Model/DataTargetDefinitionDataType.cs
@@ -72,8 +72,13 @@ namespace Symend.Client.Customer.Model
         /// Enum Guid for value: guid
         /// </summary>
         [EnumMember(Value = "guid")]
-        Guid = 7
+        Guid = 7,
 
+        /// <summary>
+        /// Enum DateOnly for value: dateOnly
+        /// </summary>
+        [EnumMember(Value = "dateOnly")]
+        DateOnly = 8
     }
 
 }

--- a/Customer.Api/customer.v1.yaml
+++ b/Customer.Api/customer.v1.yaml
@@ -1087,6 +1087,7 @@ components:
             - datetime
             - number
             - guid
+            - dateOnly
         isPii:
           type: boolean
         category:
@@ -1099,6 +1100,8 @@ components:
             - account
             - uncategorized
             - property
+            - insightEnablement
+            - cureScoresArchetypes
         structureType:
           type: string
           enum:


### PR DESCRIPTION
# Summary

Updated the `customer.v1.yaml` OpenAPI spec with recent changes to both the `DataTargetDefinitionCategory` and `DataTargetDefinitionDataType` enums.

**DataTargetDefinitionCategory:**
- `insightEnablement`
- `cureScoresArchetypes`

**DataTargetDefinitionDataType:**
- `dateOnly`
